### PR TITLE
Typo in "Klassenliste - Leistungsübersicht Jg 05 bis EF Beamerprojektion ZN QN @KL"

### DIFF
--- a/Reports Leistungsübersichten/Klassenliste - Leistungsübersicht Jg 05 bis EF Beamerprojektion ZN QN @KL.rtm
+++ b/Reports Leistungsübersichten/Klassenliste - Leistungsübersicht Jg 05 bis EF Beamerprojektion ZN QN @KL.rtm
@@ -1345,7 +1345,7 @@ object RepOrt: TppReport
       UserName = 'FehlstundenUnentschuldigt'
       AutoSize = False
       Border.mmPadding = 0
-      Caption = 'unetschuldigt'
+      Caption = 'unentschuldigt'
       Font.Charset = DEFAULT_CHARSET
       Font.Color = clBlack
       Font.Name = 'Calibri'


### PR DESCRIPTION
Typo unetschuldigt -> unentschuldigt